### PR TITLE
Checking InCall EndpointStatistics every retrieveMultipleStatistics call instead of once per device data retrieval 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.avispl.symphony.dal.device.aggregator.zoom.rooms</groupId>
     <artifactId>symphony-dal-communicator-aggregator-zoom-rooms</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <properties>
         <symphonyApiVersion>5.8.0</symphonyApiVersion>
         <timestamp>${maven.build.timestamp}</timestamp>


### PR DESCRIPTION
Checking InCall EndpointStatistics every retrieveMultipleStatistics call instead of once per device data retrieval  (latter may end up in InCall status freezing for some devices)